### PR TITLE
Fix gitlab ci integration (#3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,3 @@ RUN apk --no-cache add git ca-certificates bash openssl make \
 ENV PATH="/opt/k8s-handle:${PATH}"
 
 WORKDIR /tmp/
-ENTRYPOINT ["/usr/local/bin/python", "/opt/k8s-handle/k8s-handle.py"]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ EOF
 $ cd $WORKDIR
 $ git clone https://github.com/rvadim/k8s-handle-example.git
 $ cd k8s-handle-example
-$ docker run --rm -v $(pwd):/tmp/ -v "$HOME/.kube:/root/.kube" rvadim/k8s-handle deploy -s staging --use-kubeconfig
+$ docker run --rm -v $(pwd):/tmp/ -v "$HOME/.kube:/root/.kube" rvadim/k8s-handle k8s-handle deploy -s staging --use-kubeconfig
 INFO:templating:File "/tmp/k8s-handle/configmap.yaml" successfully generated
 INFO:templating:Trying to generate file from template "secret.yaml.j2" in "/tmp/k8s-handle"
 INFO:templating:File "/tmp/k8s-handle/secret.yaml" successfully generated


### PR DESCRIPTION
```
$ docker run --rm -it rvadim/k8s-handle:vadim /bin/sh 
/tmp # k8s-handle --help
usage: k8s-handle [-h] {deploy,destroy} ...

CLI utility generate k8s resources by templates and apply it to cluster

positional arguments:
  {deploy,destroy}
    deploy          Sub command for deploy
    destroy         Sub command for destroy app

optional arguments:
  -h, --help        show this help message and exit
/tmp #
```